### PR TITLE
fix: jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,16 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "esmodules": true } }], // It's the name of the lib you installed
-    ["@babel/preset-react", { "runtime": "automatic" }] // It's the name of the lib you installed
+    [
+      "@babel/preset-env",
+      { "targets": { "esmodules": true, "node": "current" } }
+    ], // It's the name of the lib you installed
+    ["@babel/preset-react", { "runtime": "automatic" }], // It's the name of the lib you installed
+    [
+      "babel-preset-vite",
+      {
+        "env": true,
+        "glob": false
+      }
+    ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.7",
-        "@babel/preset-env": "^7.24.7",
-        "@babel/preset-react": "^7.24.7",
+        "@babel/preset-env": "^7.26.0",
+        "@babel/preset-react": "^7.25.9",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
@@ -29,6 +29,7 @@
         "@vitejs/plugin-react-swc": "^3.6.0",
         "autoprefixer": "^10.4.18",
         "babel-jest": "^29.7.0",
+        "babel-preset-vite": "^1.1.3",
         "eslint": "^8.57.0",
         "eslint-plugin-jest": "^28.9.0",
         "eslint-plugin-react": "^7.34.0",
@@ -4247,6 +4248,81 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-glob": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-glob/-/babel-plugin-transform-vite-meta-glob-1.1.2.tgz",
+      "integrity": "sha512-o984FUo++WYnfgUaC8ymzmNPng5Kda5A6j6PFC0uOqhFXlAsD6mNhEBhaNzbUGfq/aPcyeGo67fYXlg20rh9aA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12",
+        "glob": "^10.3.10"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-glob/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-hot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-hot/-/babel-plugin-transform-vite-meta-hot-1.0.0.tgz",
+      "integrity": "sha512-qF7T46bDG5UPPOfy4MFgQJyd3mZvm1sGOR2gZ4lIHy6DEcxAVTIt39/adAn89il44CvwestshuEybKPMR+L/Tg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
+      }
+    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
@@ -4287,6 +4363,19 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-vite": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-vite/-/babel-preset-vite-1.1.3.tgz",
+      "integrity": "sha512-xSt/EiezzeMd4RI2hjMCNyn/FGzGeroKODPMAUTsgpeHC4dFf2qiCQfyNuiNzn1OwoF4n+NYSsORhUN5G/2KTA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12",
+        "babel-plugin-transform-vite-meta-env": "1.0.3",
+        "babel-plugin-transform-vite-meta-glob": "1.1.2",
+        "babel-plugin-transform-vite-meta-hot": "1.0.0"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
-    "@babel/preset-env": "^7.24.7",
-    "@babel/preset-react": "^7.24.7",
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-react": "^7.25.9",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
@@ -34,6 +34,7 @@
     "@vitejs/plugin-react-swc": "^3.6.0",
     "autoprefixer": "^10.4.18",
     "babel-jest": "^29.7.0",
+    "babel-preset-vite": "^1.1.3",
     "eslint": "^8.57.0",
     "eslint-plugin-jest": "^28.9.0",
     "eslint-plugin-react": "^7.34.0",

--- a/src/__tests__/components/Layout.test.js
+++ b/src/__tests__/components/Layout.test.js
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { Layout } from "../../components/Layout";
+import { AppStoreProvider } from "../../providers/Store";
+
+describe("<Layout />", () => {
+  it("should render children", () => {
+    jest.doMock("../../components/ErrorFallback.jsx", () => {
+      const MockedComponent = (props) => (
+        <div data-testid="mocked-child">{`Mocked Child with prop: ${props.someProp}`}</div>
+      );
+      MockedComponent.displayName = "MockedComponent";
+      return MockedComponent;
+    });
+    const { container } = render(
+      <AppStoreProvider>
+        <Layout />
+      </AppStoreProvider>
+    );
+    expect(container.children.length).toBeGreaterThan(0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,7 +835,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.25.9"
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/preset-env@^7.24.7":
+"@babel/preset-env@^7.26.0":
   version "7.26.0"
   resolved "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz"
   integrity sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==
@@ -919,7 +919,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@^7.24.7":
+"@babel/preset-react@^7.25.9":
   version "7.25.9"
   resolved "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.25.9.tgz"
   integrity sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==
@@ -931,7 +931,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.25.9"
     "@babel/plugin-transform-react-pure-annotations" "^7.25.9"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.9", "@babel/runtime@^7.8.4":
   version "7.26.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -1421,7 +1421,7 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
-"@types/babel__core@^7.1.14":
+"@types/babel__core@^7.1.12", "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -1885,6 +1885,31 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.3"
 
+babel-plugin-transform-vite-meta-env@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz"
+  integrity sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+    "@types/babel__core" "^7.1.12"
+
+babel-plugin-transform-vite-meta-glob@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-vite-meta-glob/-/babel-plugin-transform-vite-meta-glob-1.1.2.tgz"
+  integrity sha512-o984FUo++WYnfgUaC8ymzmNPng5Kda5A6j6PFC0uOqhFXlAsD6mNhEBhaNzbUGfq/aPcyeGo67fYXlg20rh9aA==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+    "@types/babel__core" "^7.1.12"
+    glob "^10.3.10"
+
+babel-plugin-transform-vite-meta-hot@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-vite-meta-hot/-/babel-plugin-transform-vite-meta-hot-1.0.0.tgz"
+  integrity sha512-qF7T46bDG5UPPOfy4MFgQJyd3mZvm1sGOR2gZ4lIHy6DEcxAVTIt39/adAn89il44CvwestshuEybKPMR+L/Tg==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+    "@types/babel__core" "^7.1.12"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz"
@@ -1913,6 +1938,17 @@ babel-preset-jest@^29.6.3:
   dependencies:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
+
+babel-preset-vite@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/babel-preset-vite/-/babel-preset-vite-1.1.3.tgz"
+  integrity sha512-xSt/EiezzeMd4RI2hjMCNyn/FGzGeroKODPMAUTsgpeHC4dFf2qiCQfyNuiNzn1OwoF4n+NYSsORhUN5G/2KTA==
+  dependencies:
+    "@babel/runtime" "^7.13.9"
+    "@types/babel__core" "^7.1.12"
+    babel-plugin-transform-vite-meta-env "1.0.3"
+    babel-plugin-transform-vite-meta-glob "1.1.2"
+    babel-plugin-transform-vite-meta-hot "1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Reference: [Jest and Vite: Cannot use import.meta outside a module](https://dev.to/rubymuibi/jest-and-vite-cannot-use-importmeta-outside-a-module-24n3)